### PR TITLE
Without the related fix, this new Test was failing because:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 jdk:
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
   include:
     - jdk: openjdk7
       script: cd restygwt; mvn verify -Prun-its -Dmaven.test.skip -Dinvoker.test=restygwt-overlay-example
-    - jdk: oraclejdk7
-      script: cd restygwt; mvn verify -Prun-its -Dmaven.test.skip -Dinvoker.test=restygwt-rails-*
     - jdk: oraclejdk8
       script: cd restygwt; mvn verify -Prun-its -Dmaven.test.skip -Dinvoker.test=restygwt-example
     - jdk: oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.fusesource.restygwt</groupId>
   <artifactId>restygwt-project</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.1</version>
   <packaging>pom</packaging>
   
   <name>${project.artifactId}</name>

--- a/restygwt/pom.xml
+++ b/restygwt/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.fusesource.restygwt</groupId>
     <artifactId>restygwt-project</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/UI.gwt.xml
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/UI.gwt.xml
@@ -27,6 +27,7 @@
 
   <servlet path='/pizza-service/toppings' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
   <servlet path='/pizza-service/ping' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
+  <servlet path='/pizza-service/crusts' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
   <servlet path='/pizza-service' class='org.fusesource.restygwt.examples.server.PizzaServlet'/>
   <servlet path='/jsonp-service' class='org.fusesource.restygwt.examples.server.JsonpServlet'/>
   <servlet path='/test/method' class='org.fusesource.restygwt.examples.server.TestServlet'/>

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/CheesyCrust.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/CheesyCrust.java
@@ -1,0 +1,8 @@
+package org.fusesource.restygwt.examples.client;
+
+
+public class CheesyCrust implements Crust {
+    public String getName() {
+        return "cheesy";
+    }
+}

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/Crust.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/Crust.java
@@ -1,0 +1,10 @@
+package org.fusesource.restygwt.examples.client;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use=Id.CLASS, include=As.PROPERTY, property="class")
+public interface Crust {
+    String getName();
+}

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/PizzaService.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/PizzaService.java
@@ -21,6 +21,7 @@ package org.fusesource.restygwt.examples.client;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.OPTIONS;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -29,6 +30,7 @@ import org.fusesource.restygwt.client.MethodCallback;
 import org.fusesource.restygwt.client.RestService;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 
@@ -44,6 +46,11 @@ public interface PizzaService extends RestService {
     @Path("/toppings")
     @Produces( MediaType.APPLICATION_JSON )
     public void listToppings(MethodCallback<List<Topping>> callback);
+
+    @OPTIONS
+    @Path("/crusts")
+    @Produces( MediaType.APPLICATION_JSON )
+    public void getCurstPrices(Crust crust, MethodCallback<Map<Integer, Double>> callback);
 
     @DELETE
     @Path("/ping")

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/ThinCrust.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/client/ThinCrust.java
@@ -1,0 +1,9 @@
+package org.fusesource.restygwt.examples.client;
+
+public class ThinCrust implements Crust {
+
+	public String getName() {
+		return "thin";
+	}
+
+}

--- a/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/server/PizzaServlet.java
+++ b/restygwt/src/it/restygwt-example/src/main/java/org/fusesource/restygwt/examples/server/PizzaServlet.java
@@ -21,6 +21,8 @@ package org.fusesource.restygwt.examples.server;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -99,6 +101,31 @@ public class PizzaServlet extends HttpServlet {
 
             resp.setContentType(Resource.CONTENT_TYPE_JSON);
             mapper.writeValue(resp.getOutputStream(), toppings);
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+        } finally {
+            System.out.flush();
+            System.err.flush();
+        }
+    }
+
+    @Override
+    protected  void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        System.out.println("Processing Crust prices");
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+
+            Map<Integer, Double> prices = new HashMap<Integer, Double>();
+            prices.put(28, 1.5);
+            prices.put(32, 2.0);
+
+            StringWriter sw = new StringWriter();
+            mapper.writeValue(sw, prices);
+            System.out.println("Response: " + sw.toString());
+
+            resp.setContentType(Resource.CONTENT_TYPE_JSON);
+            mapper.writeValue(resp.getOutputStream(), prices);
 
         } catch (Throwable e) {
             e.printStackTrace();

--- a/restygwt/src/it/restygwt-example/src/test/java/org/fusesource/restygwt/examples/client/PizzaServiceUITestGWT.java
+++ b/restygwt/src/it/restygwt-example/src/test/java/org/fusesource/restygwt/examples/client/PizzaServiceUITestGWT.java
@@ -24,6 +24,7 @@ import org.fusesource.restygwt.client.MethodCallback;
 import com.google.gwt.core.client.GWT;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 
@@ -116,6 +117,27 @@ public class PizzaServiceUITestGWT extends UITestGWT {
             }
         });
 
+        delayTestFinish(2000);
+    }
+
+    public void testCrustPrices() {
+        Crust crust = new CheesyCrust();
+        // Initialize the pizza service..
+        PizzaService service = GWT.create(PizzaService.class);
+
+        service.getCurstPrices(crust, new MethodCallback<Map<Integer, Double>>(){
+            public void onSuccess(Method method, Map<Integer, Double> response) {
+                System.out.println(response);
+                assertNotNull(response);
+                assertEquals(2, response.size());
+                finishTest();
+            }
+            public void onFailure(Method method, Throwable exception) {
+                exception.printStackTrace();
+                fail(exception.getMessage());
+            }
+
+        });
         delayTestFinish(2000);
     }
 }

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/PossibleTypesVisitor.java
@@ -149,7 +149,7 @@ public class PossibleTypesVisitor extends JsonTypeInfoIdVisitor<List<Subtype>, U
         final List<Subtype> possibleTypes = Lists.newArrayList();
         List<JClassType> resolvedSubtypes = Lists.newArrayList();
 
-        if (types != null) {
+        if (types != null && !types.isEmpty()) {
             for (JsonSubTypes.Type type : types) {
                 JClassType typeClass = BaseSourceCreator.find(type.value(), logger, context);
                 if (!isLeaf || classType.equals(typeClass))

--- a/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
+++ b/restygwt/src/main/java/org/fusesource/restygwt/rebind/RestServiceClassCreator.java
@@ -657,13 +657,10 @@ public class RestServiceClassCreator extends BaseSourceCreator {
                 } else if (contentArg.getType() == DOCUMENT_TYPE) {
                     p("__method.xml(" + contentArg.getName() + ");");
                 } else {
-                    JClassType contentClass = contentArg.getType().isClass();
+                    JClassType contentClass = contentArg.getType().isClassOrInterface();
                     if (contentClass == null) {
-                        contentClass = contentArg.getType().isClassOrInterface();
-                        if (!locator.isCollectionType(contentClass)) {
-                            getLogger().log(ERROR, "Content argument must be a class.");
-                            throw new UnableToCompleteException();
-                        }
+                        getLogger().log(ERROR, "Content argument must be a class.");
+                        throw new UnableToCompleteException();
                     }
 
                     jsonAnnotation = getAnnotation(contentArg, Json.class);

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectExampleService.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectExampleService.java
@@ -25,6 +25,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -35,6 +37,9 @@ public interface DirectExampleService extends DirectRestService {
 
     @GET @Path("/list")
     List<ExampleDto> getExampleDtos(@QueryParam("id") String id);
+
+    @GET @Path("/date")
+    Long getDate(@QueryParam("date") Date date);
 
     @POST @Path("/store")
     void storeDto(ExampleDto exampleDto);

--- a/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/client/basic/DirectRestServiceTestGwt.java
@@ -22,6 +22,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.junit.client.GWTTestCase;
 import org.fusesource.restygwt.client.*;
 
+import java.util.Date;
 import java.util.List;
 
 import javax.ws.rs.GET;
@@ -72,6 +73,30 @@ public class DirectRestServiceTestGwt extends GWTTestCase {
                 fail(e.getMessage());
             }
         }).call(directExampleService).getExampleDtos("3");
+    }
+
+    public void testDateFormat() {
+        delayTestFinish(10000);
+        DirectExampleService directExampleService = GWT.create(DirectExampleService.class);
+
+        Resource resource = new Resource(GWT.getModuleBaseURL() + "api");
+        ((RestServiceProxy) directExampleService).setResource(resource);
+
+        Defaults.setDateFormat(null);
+
+        final Date date = new Date(1506224400000L);
+        REST.withCallback(new MethodCallback<Long>() {
+            @Override
+            public void onSuccess(Method method, Long response) {
+                assertEquals(date.getTime(), response.longValue());
+                finishTest();
+            }
+
+            @Override
+            public void onFailure(Method method, Throwable e) {
+                fail(e.getMessage());
+            }
+        }).call(directExampleService).getDate(date);
     }
 
     public void testRegexPathParamCall() {

--- a/restygwt/src/test/java/org/fusesource/restygwt/server/basic/DirectServiceTestGwtServlet.java
+++ b/restygwt/src/test/java/org/fusesource/restygwt/server/basic/DirectServiceTestGwtServlet.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Date;
 
 /**
  * A servlet that just implements the services required for the direct service test.
@@ -37,7 +38,9 @@ public class DirectServiceTestGwtServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
 
-        if (request.getRequestURI().endsWith("/api/list")) {
+        if (request.getRequestURI().endsWith("/date")) {
+            response.getWriter().print(Long.parseLong(request.getParameter("date")));
+        } else if (request.getRequestURI().endsWith("/api/list")) {
             response.getWriter().print(THREE_ELEMENT_LIST);
         } else if (request.getRequestURI().matches(".+/\\d+")) {
             String url = request.getRequestURI();


### PR DESCRIPTION
Actual URI:
/api/date?date=Sun+Sep+24+13%3A40%3A00+AEST+2017

Expected URI:
/api/date?date=1506224400000

Starting Jetty on port 0
   [WARN] /org.fusesource.restygwt.DirectRestServiceTestGwt.JUnit/api/date
java.lang.NumberFormatException: For input string: "Sun Sep 24 13:40:00 AEST 2017"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.parseLong(Long.java:631)
	at org.fusesource.restygwt.server.basic.DirectServiceTestGwtServlet.doGet(DirectServiceTestGwtServlet.java:42)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:735)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:686)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:501)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:137)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:557)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:231)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:428)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:193)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
	at org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:68)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
	at org.eclipse.jetty.server.Server.handle(Server.java:370)
	at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:489)
	at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:949)
	at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1011)
	at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:644)
	at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:235)
	at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:668)
	at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:52)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)
	at java.lang.Thread.run(Thread.java:748)
[ERROR] 500 - GET /org.fusesource.restygwt.DirectRestServiceTestGwt.JUnit/api/date?date=Sun+Sep+24+13%3A40%3A00+AEST+2017 (10.10.10.252) 4029 bytes